### PR TITLE
Use short day names for Dutch translation

### DIFF
--- a/locales.js
+++ b/locales.js
@@ -312,13 +312,13 @@ const locales = {
   /* Dutch */
   'nl_nl-NL_nl-BE': {
     days: [
-      `Zondag`,
-      `Maandag`,
-      `Dinsdag`,
-      `Woensdag`,
-      `Donderdag`,
-      `Vrijdag`,
-      `Zaterdag`
+      `Zo`,
+      `Ma`,
+      `Di`,
+      `Wo`,
+      `Do`,
+      `Vr`,
+      `Za`
     ],
     months: [
       `Januari`,


### PR DESCRIPTION
Long day names mess up the layout of the date picker.